### PR TITLE
Fix permissions for `/birthday update` and `/birthday remove`

### DIFF
--- a/src/commands/general/birthday/remove.ts
+++ b/src/commands/general/birthday/remove.ts
@@ -25,7 +25,7 @@ export class ListCommand extends Command {
 
 		if (
 			interaction.user.id !== targetUser.id &&
-			!(await hasUserGuildPermissions({ interaction, user: targetUser, permissions: ['ManageRoles'] }))
+			!(await hasUserGuildPermissions({ interaction, user: interaction.user, permissions: ['ManageRoles'] }))
 		) {
 			return replyToInteraction(interaction, {
 				embeds: [

--- a/src/commands/general/birthday/update.ts
+++ b/src/commands/general/birthday/update.ts
@@ -93,7 +93,7 @@ export class UpdateCommand extends Command {
 		const { guildId } = interaction;
 		if (
 			interaction.user.id !== targetUser.id &&
-			!(await hasUserGuildPermissions({ interaction, user: targetUser.id, permissions: ['ManageRoles'] }))
+			!(await hasUserGuildPermissions({ interaction, user: interaction.user.id, permissions: ['ManageRoles'] }))
 		) {
 			return replyToInteraction(interaction, {
 				embeds: [


### PR DESCRIPTION
Currently, the bot checks if the user you are updating has Manage Roles. That is incorrect. This PR changes that to check if the user running the interaction has the correct permissions.

Untested, but I believe it should work.