### PR TITLE
[Feats] Add support for retrieving Premium Guilds

### DIFF
--- a/src/lib/premium/getGuilds.ts
+++ b/src/lib/premium/getGuilds.ts
@@ -1,3 +1,13 @@
+import { container } from '@sapphire/framework';
+
 export default function getPremiumGuilds() {
-	// TODO: #11 Get premium guilds from API
+	return container.prisma.guild.findMany({
+		where: {
+			premium: true,
+		},
+		select: {
+			guildId: true,
+			premium: true,
+		},
+	});
 }

--- a/src/routes/guild/retrieve/byPremium.ts
+++ b/src/routes/guild/retrieve/byPremium.ts
@@ -1,0 +1,15 @@
+import { ApplyOptions } from '@sapphire/decorators';
+import { ApiRequest, ApiResponse, Route, methods } from '@sapphire/plugin-api';
+import getPremiumGuilds from '../../../lib/premium/getGuilds';
+
+@ApplyOptions<Route.Options>({
+	name: 'byPremium',
+	route: 'guild/retrieve/byPremium',
+})
+export class GuildsPremium extends Route {
+	public async [methods.GET](_request: ApiRequest, response: ApiResponse) {
+		const guilds = await getPremiumGuilds();
+
+		return response.status(200).json(guilds);
+	}
+}

--- a/src/routes/guild/retrieve/byPremium.ts
+++ b/src/routes/guild/retrieve/byPremium.ts
@@ -1,12 +1,14 @@
 import { ApplyOptions } from '@sapphire/decorators';
-import { ApiRequest, ApiResponse, Route, methods } from '@sapphire/plugin-api';
+import { ApiRequest, ApiResponse, methods, Route } from '@sapphire/plugin-api';
+import { authenticated } from '../../../lib/api/utils';
 import getPremiumGuilds from '../../../lib/premium/getGuilds';
 
 @ApplyOptions<Route.Options>({
 	name: 'byPremium',
 	route: 'guild/retrieve/byPremium',
 })
-export class GuildsPremium extends Route {
+export class PremiumGuilds extends Route {
+	@authenticated()
 	public async [methods.GET](_request: ApiRequest, response: ApiResponse) {
 		const guilds = await getPremiumGuilds();
 


### PR DESCRIPTION
This commit adds support for retrieving premium guilds. The `getGuilds.ts` file now exports a function that retrieves all guilds that have the `premium` property set to `true`. The `byPremium.ts` file is a new file that defines a route for retrieving premium guilds. The route uses the `getPremiumGuilds` function to retrieve the guilds and returns them as a JSON response.